### PR TITLE
add W503 to flake8 ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -148,7 +148,17 @@ docstring_convention = google
 # E501 prevents flake8 from complaining line lengths > 79. We will use
 # flake8-bugbear's B950 to handle line length lint errors. This trips
 # when a line is > max-line-length + 10%.
-extend-ignore = E203, E501
+#
+# W503 is ignored for not just because it makes use of
+# left-aligned binary operators in multi-line expressions, but because the
+# opposite advice is now the recommended practice; see
+# • https://rhodesmill.org/brandon/slides/2012-11-pyconca/#laying-down-the-law
+# • https://github.com/PyCQA/pycodestyle/pull/502
+# • https://www.flake8rules.com/rules/W503.html
+# • ET Tufte, _Seeing with Fresh Eyes: Meaning, Space, Data, Truth_, Graphics
+#   Press 2020, p.14.
+
+extend-ignore = E203, E501, W503
 
 # Selects following test categories:
 # D: Docstring errors and warnings


### PR DESCRIPTION
## 🗒️ Summary
Per title, following discussion with @jordanpadams and @nutjob4life.

Bad rule ([reversed by PEP8 in 2016](https://www.flake8rules.com/rules/W503.html)) is bad.

