### PR TITLE
Clean up trailing white space in imported codeql-analysis.yml file

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,25 +69,25 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-    
+
     - run: |
         pip install nasa-scrub
-        
+
         results_dir=`realpath ${{ github.workspace }}/../results`
         sarif_files=`find $results_dir -name '*.sarif'`
-        
+
         for sarif_file in $sarif_files
         do
           output_file="$results_dir/$(basename $sarif_file .sarif).scrub"
-          
+
           python3 -m scrub.tools.parsers.translate_results $sarif_file $output_file ${{ github.workspace }} scrub
         done
-        
+
         python3 -m scrub.tools.parsers.csv_parser $results_dir
-        
+
         echo "RESULTS_DIR=$results_dir" >> $GITHUB_ENV
-        
-      
+
+
     - name: Upload CodeQL Artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
## 🗒️ Summary

Merge this to make the `branch_cicd.yaml` workflow happy by cleaning up trailing whitespace in the `codeql-analysis.yml` file.

## ⚙️ Test Data and/or Report
```
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Check Yaml...............................................................Passed
Reorder python imports...................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
Git Secrets..............................................................Passed
```

## ♻️ Related Issues

- #67 
