### PR TITLE
Add missing backslash to secrets detection GitHub Actions workflow file

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -54,7 +54,7 @@ jobs:
                         --exclude-files 'venv' \
                         --exclude-files 'dist' \
                         --exclude-files 'build' \
-                        --exclude-files '.*\.egg-info'
+                        --exclude-files '.*\.egg-info' \
                         --exclude-files '\.pre-commit-config.yaml'
 
                     # if there is any difference between the known and newly detected secrets, break the build

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,7 @@
       "pattern": [
         "\\.secrets..*",
         "\\.git.*",
+        "\\.pre-commit-config\\.yaml",
         "\\.mypy_cache",
         "\\.pytest_cache",
         "\\.tox",
@@ -139,16 +140,6 @@
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "63076edad0be7557f5fbd9b60bc1ffa664fce207",
-        "is_verified": false,
-        "line_number": 57,
-        "is_secret": false
-      }
-    ],
     "setup.cfg": [
       {
         "type": "Email Address",
@@ -160,5 +151,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-09T15:22:01Z"
+  "generated_at": "2024-10-02T16:13:34Z"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build -a -b html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
## 🗒️ Summary

While working with @dbuccino we noticed that the secrets detection workflow in GitHub Actions was failing. It turned out there was a missing backslash in the `.secrets-detection.yaml` file.

## ⚙️ Test Data and/or Report

See @dbuccino's [commit](https://github.com/NASA-PDS/PyTrk234/commit/10224fe6aa3dc80c142e85bf9d0c9872c229883e) and the secrets detection workflow it triggered in his corrected repository created from the template, which worked.

## ♻️ Related Issues

N/A