### PR TITLE
Sonarcloud Code Coverage

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -57,8 +57,11 @@ jobs:
             -
                 name: 🩺 Testing and coverage
                 run: |
-                    coverage run --module pytest
+                    echo '1️⃣ Running coverage run'
+                    coverage run --source=src/pds --module pytest
+                    echo '2️⃣ Running coverage xml'
                     coverage xml
+                    echo '3️⃣ there is no step 3'
             -
                 name: 📡 Sonar scan
                 uses: SonarSource/sonarcloud-github-action@v2

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -1,0 +1,75 @@
+# 🏃‍♀️ SonarCloud: Code Quality and Coverage
+# ========================================
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository:
+#
+# - `SONAR_CLOUD` — an access token which you can from sonarcloud.io
+
+---
+
+name: 📡☁️ SonarCloud
+
+
+# Driving Event
+
+on:
+    push:
+        branches:
+            - 'main'
+            - 'i104'  # For testing purposes; should be removed
+    pull_request:
+        types: [opened, synchronize, reopened]
+
+
+# What to Do
+
+jobs:
+    sonar:
+        name: 📡☁️ SonarCloud Analysis
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: 💳 Checkout
+                uses: actions/checkout@v4
+                with:
+                    lfs: true
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    fetch-depth: 0
+            -
+                name: 💵 Python Cache
+                uses: actions/cache@v4
+                with:
+                    path: ~/.cache/pip
+                    key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
+                    # To restore a set of files, we only need to match a prefix of the saved key.
+                    restore-keys: pds-${{runner.os}}-py-
+            -
+                name: 🐍 Python
+                uses: actions/setup-python@v5
+                with:
+                    python-version: '3.9'
+            -
+                name: 👷 Installation
+                run: |
+                    python3 -m pip install --upgrade --quiet pip
+                    pip install --editable '.[dev]'
+            -
+                name: 🩺 Testing and coverage
+                run: |
+                    coverage run --module pytest
+                    coverage xml
+            -
+                name: 📡 Sonar scan
+                uses: SonarSource/sonarcloud-github-action@v2
+                with:
+                    args: >
+                        -Dsonar.projectKey=NASA-PDS_template-repo-python
+                        -Dsonar.organization=NASA-PDS
+                        -Dsonar.python.coverage.reportPaths=coverage.xml
+                env:
+                    SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+
+...
+
+# -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -68,7 +68,7 @@ jobs:
                 with:
                     args: >
                         -Dsonar.projectKey=NASA-PDS_template-repo-python
-                        -Dsonar.organization=NASA-PDS
+                        -Dsonar.organization=nasa-pds
                         -Dsonar.python.coverage.reportPaths=coverage.xml
                 env:
                     SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -17,7 +17,7 @@ on:
     push:
         branches:
             - 'main'
-            - 'i104'  # For testing purposes; should be removed
+            - 'i104'  # For testing purposes; should be removed once we confirm it working end-to-end
     pull_request:
         types: [opened, synchronize, reopened]
 

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -17,7 +17,7 @@ on:
     push:
         branches:
             - 'main'
-            - 'i104'  # For testing purposes; should be removed once we confirm it working end-to-end
+            - 'i104'  # For testing purposes; should be removed once we confirm it working
     pull_request:
         types: [opened, synchronize, reopened]
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ pip-selfcheck.json
 
 # Python testing artifacts
 .coverage
+coverage.xml
 htmlcov
 .tox/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ dev =
     sphinxcontrib-htmlhelp==1.0.0
     sphinxcontrib.serializinghtml==1.1.1
     sphinxcontrib.qthelp==1.0.2
+    alabaster==0.7.13
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ dev =
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
     sphinxcontrib-applehelp==1.0.4
-    sphinxcontrib-devhelp==1.0.5
+    sphinxcontrib-devhelp==1.0.0
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ dev =
     pre-commit~=3.3.3
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
-    sphinxcontrib-applehelp~=1.0.4
+    sphinxcontrib-applehelp==1.0.4
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ dev =
     pre-commit~=3.3.3
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
+    sphinxcontrib-applehelp~=1.0.4
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ package_dir =
 packages = find_namespace:
 python_requires = >= 3.9
 
+
 [options.extras_require]
 dev =
     black~=23.7.0
@@ -77,10 +78,12 @@ dev =
     types-setuptools~=68.1.0.0
     Jinja2<3.1
 
+
 [options.entry_points]
 # Put your entry point scripts here
-#console_scripts =
-    # some_script: ...
+console_scripts =
+    hello-world = pds.your_package_name.main:main
+
 
 [options.packages.find]
 # Don't change this. Needed to find packages under src/
@@ -117,7 +120,7 @@ omit = */_version.py,*/__init__.py
 #
 # See https://docs.pytest.org/ for more information.
 [tool:pytest]
-addopts = -n auto --cov=pds
+addopts = -n auto --cov=pds --cov-report=xml --cov-report=term
 
 
 # Installation Options

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ dev =
     sphinxcontrib-applehelp==1.0.4
     sphinxcontrib-devhelp==1.0.0
     sphinxcontrib-htmlhelp==1.0.0
+    sphinxcontrib.serializinghtml==1.0.0
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,7 +120,7 @@ omit = */_version.py,*/__init__.py
 #
 # See https://docs.pytest.org/ for more information.
 [tool:pytest]
-addopts = -n auto --cov=pds --cov-report=xml --cov-report=term
+addopts = --numprocesses auto --cov=pds --cov-report=xml --cov-report=term
 
 
 # Installation Options

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ dev =
     sphinxcontrib-devhelp==1.0.0
     sphinxcontrib-htmlhelp==1.0.0
     sphinxcontrib.serializinghtml==1.1.1
+    sphinxcontrib.qthelp==1.0.2
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ dev =
     sphinxcontrib-applehelp==1.0.4
     sphinxcontrib-devhelp==1.0.0
     sphinxcontrib-htmlhelp==1.0.0
-    sphinxcontrib.serializinghtml==1.1.0
+    sphinxcontrib.serializinghtml==1.1.1
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ dev =
     sphinxcontrib-applehelp==1.0.4
     sphinxcontrib-devhelp==1.0.0
     sphinxcontrib-htmlhelp==1.0.0
-    sphinxcontrib.serializinghtml==1.0.0
+    sphinxcontrib.serializinghtml==1.1.0
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ dev =
     sphinx~=3.2.1
     sphinx-rtd-theme~=0.5.0
     sphinxcontrib-applehelp==1.0.4
+    sphinxcontrib-devhelp==1.0.5
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ dev =
     sphinx-rtd-theme~=0.5.0
     sphinxcontrib-applehelp==1.0.4
     sphinxcontrib-devhelp==1.0.0
+    sphinxcontrib-htmlhelp==2.0.4
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ packages = find_namespace:
 python_requires = >= 3.9
 
 
+# We really need to upgrade Sphinx beyond v3; this is a mess
 [options.extras_require]
 dev =
     black~=23.7.0
@@ -76,7 +77,7 @@ dev =
     sphinx-rtd-theme~=0.5.0
     sphinxcontrib-applehelp==1.0.4
     sphinxcontrib-devhelp==1.0.0
-    sphinxcontrib-htmlhelp==2.0.4
+    sphinxcontrib-htmlhelp==1.0.0
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/src/pds/your_package_name/main.py
+++ b/src/pds/your_package_name/main.py
@@ -1,0 +1,17 @@
+# encoding: utf-8
+"""Main demonstration module."""
+
+
+def getgreeting() -> str:
+    """Return an appropriate greeting."""
+    return "Heya, 🌎"
+
+
+def main():
+    """Main entrypoint."""
+    greeting = getgreeting()
+    print(greeting)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pds/your_package_name/test_example.py
+++ b/tests/pds/your_package_name/test_example.py
@@ -1,9 +1,17 @@
+# encoding: utf-8
+"""Example tests."""
 import unittest
 
 
 class HelloWorldTests(unittest.TestCase):
-    def test_example(self):
-        assert True
+    """Example test of the greeting."""
+
+    def test_greeting(self):
+        """Ensure the ``getgreeting`` function works as expected."""
+        from pds.your_package_name.main import getgreeting
+
+        greeting = getgreeting()
+        self.assertEqual("Heya, 🌎", greeting, "Expected greeting does not match … er … expectations")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add code coverage reporting to SonarQube Cloud (a.k.a. Sonarcloud). This also fixes some long-standing version pin problems in the branch testing workflow (and serves as a reminder that we desperately need to upgrade our Sphinx documentation generation, [attached as a comment to the Python infrastructure upgrade ticket](https://github.com/NASA-PDS/template-repo-python/issues/105#issuecomment-2866754297)).

## ⚙️ Test Data and/or Report

I would direct you to see the [code coverage report at at Sonarcloud](https://sonarcloud.io/project/branches_list?id=NASA-PDS_template-repo-python), except that our current free plan does not show such reports for any branch other than `main`. You'll have to merge this to `main` to actually get the report to show up.

However, you can see that the `coverage.xml` is at least generated locally:
```console
$ ls -l coverage.xml
ls: coverage.xml: No such file or directory
$ tox --quiet -e py39
…
  py39: OK (3.62 seconds)
  congratulations :) (3.85 seconds)
$ ls -l coverage.xml
-rw-r--r--  1 kelly  staff  1193 May  9 09:26 coverage.xml
```

## ♻️ Related Issues

- #104 
